### PR TITLE
Player physics improvements

### DIFF
--- a/components/enemy/enemy.gd
+++ b/components/enemy/enemy.gd
@@ -71,7 +71,7 @@ func _on_gravity_changed(new_gravity):
 func _on_hitbox_body_entered(body):
 	if body.name == "Player":
 		if squashable and body.velocity.y > 0 and body.position.y < position.y:
-			body.velocity.y = body.jump_velocity
+			body.stomp()
 			queue_free()
 		elif player_loses_life:
 			Global.lives -= 1

--- a/components/player/player.tscn
+++ b/components/player/player.tscn
@@ -14,6 +14,21 @@ floor_constant_speed = true
 floor_snap_length = 32.0
 script = ExtResource("1_w3ms2")
 
+[node name="DoubleJumpParticles" type="CPUParticles2D" parent="."]
+unique_name_in_owner = true
+emitting = false
+amount = 60
+lifetime = 0.2
+one_shot = true
+explosiveness = 0.54
+randomness = 0.25
+emission_shape = 1
+emission_sphere_radius = 36.72
+particle_flag_align_y = true
+gravity = Vector2(0, 1)
+scale_amount_max = 5.0
+color = Color(1, 1, 0, 1)
+
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 unique_name_in_owner = true
 position = Vector2(0, -64)

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -86,6 +86,22 @@ func _on_gravity_changed(new_gravity):
 	gravity = new_gravity
 
 
+func _jump():
+	velocity.y = jump_velocity
+	coyote_timer = 0
+	jump_buffer_timer = 0
+	if double_jump_armed:
+		double_jump_armed = false
+		_double_jump_particles.emitting = true
+	elif double_jump:
+		double_jump_armed = true
+
+
+func stomp():
+	double_jump_armed = false
+	_jump()
+
+
 func _physics_process(delta):
 	# Don't move if there are no lives left.
 	if Global.lives <= 0:
@@ -100,14 +116,7 @@ func _physics_process(delta):
 		jump_buffer_timer = (jump_buffer + delta)
 
 	if jump_buffer_timer > 0 and (double_jump_armed or coyote_timer > 0):
-		velocity.y = jump_velocity
-		coyote_timer = 0
-		jump_buffer_timer = 0
-		if double_jump_armed:
-			double_jump_armed = false
-			_double_jump_particles.emitting = true
-		elif double_jump:
-			double_jump_armed = true
+		_jump()
 
 	# Reduce velocity if the player lets go of the jump key before the apex.
 	# This allows controlling the height of the jump.

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -23,8 +23,16 @@ extends CharacterBody2D
 ## margin for error before they start falling.
 @export_range(0, 0.5, 1 / 60.0, "suffix:s") var coyote_time: float = 5.0 / 60.0
 
+## If the character is about to land on the floor, how early can the player
+## the jump key to jump as soon as the character lands? This is often set to
+## a small positive number to allow the player a little margin for error.
+@export_range(0, 0.5, 1 / 60.0, "suffix:s") var jump_buffer: float = 5.0 / 60.0
+
 # If positive, the player is either on the ground, or left the ground less than this long ago
 var coyote_timer: float = 0
+
+# If positive, the player pressed jump this long ago
+var jump_buffer_timer: float = 0
 
 # Get the gravity from the project settings to be synced with RigidBody nodes.
 var gravity = ProjectSettings.get_setting("physics/2d/default_gravity")
@@ -77,9 +85,13 @@ func _physics_process(delta):
 	if is_on_floor():
 		coyote_timer = (coyote_time + delta)
 
-	if Input.is_action_just_pressed("ui_accept") and coyote_timer > 0:
+	if Input.is_action_just_pressed("ui_accept"):
+		jump_buffer_timer = (jump_buffer + delta)
+
+	if jump_buffer_timer > 0 and coyote_timer > 0:
 		velocity.y = jump_velocity
 		coyote_timer = 0
+		jump_buffer_timer = 0
 
 	# Reduce velocity if the player lets go of the jump key before the apex.
 	# This allows controlling the height of the jump.
@@ -113,12 +125,14 @@ func _physics_process(delta):
 	move_and_slide()
 
 	coyote_timer -= delta
+	jump_buffer_timer -= delta
 
 
 func reset():
 	position = original_position
 	velocity = Vector2.ZERO
 	coyote_timer = 0
+	jump_buffer_timer = 0
 
 
 func _on_lives_changed():

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -13,6 +13,11 @@ extends CharacterBody2D
 ## be influenced by the [member GameLogic.gravity].
 @export_range(-1000, 1000, 10, "suffix:px/s") var jump_velocity = -880.0
 
+## How much should the character's jump be reduced if you let go of the jump
+## key before the top of the jump? [code]0[/code] means “not at all”;
+## [code]100[/code] means “upwards movement completely stops”.
+@export_range(0, 100, 5, "suffix:%") var jump_cut_factor: float = 20
+
 # Get the gravity from the project settings to be synced with RigidBody nodes.
 var gravity = ProjectSettings.get_setting("physics/2d/default_gravity")
 var original_position: Vector2
@@ -67,6 +72,11 @@ func _physics_process(delta):
 	# Handle jump.
 	if Input.is_action_just_pressed("ui_accept") and is_on_floor():
 		velocity.y = jump_velocity
+
+	# Reduce velocity if the player lets go of the jump key before the apex.
+	# This allows controlling the height of the jump.
+	if Input.is_action_just_released("ui_accept") and velocity.y < 0:
+		velocity.y *= (1 - (jump_cut_factor / 100.00))
 
 	# Get the input direction and handle the movement/deceleration.
 	# As good practice, you should replace UI actions with custom gameplay actions.

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -9,6 +9,9 @@ extends CharacterBody2D
 @export_range(0, 1000, 10, "suffix:px/s") var speed: float = 500.0:
 	set = _set_speed
 
+## How fast does your character accelerate?
+@export_range(0, 5000, 1000, "suffix:px/s²") var acceleration: float = 5000.0
+
 ## How high does your character jump? Note that the gravity will
 ## be influenced by the [member GameLogic.gravity].
 @export_range(-1000, 1000, 10, "suffix:px/s") var jump_velocity = -880.0
@@ -106,9 +109,13 @@ func _physics_process(delta):
 	# As good practice, you should replace UI actions with custom gameplay actions.
 	var direction = Input.get_axis("ui_left", "ui_right")
 	if direction:
-		velocity.x = direction * speed
+		velocity.x = move_toward(
+			velocity.x,
+			sign(direction) * speed,
+			abs(direction) * acceleration * delta,
+		)
 	else:
-		velocity.x = move_toward(velocity.x, 0, speed)
+		velocity.x = move_toward(velocity.x, 0, acceleration * delta)
 
 	if velocity == Vector2.ZERO:
 		_sprite.play("idle")


### PR DESCRIPTION
This adds a few nice adjustments to the player controls:

- You get a few frames' grace after walking off a ledge where you can still jump ("coyote time")
- You get a few frames' grace if you press jump just before the character lands from a previous jump/fall ("jump buffering")
- You can control the height of the jump by releasing the jump key before the player reaches the top of the arc and starts descending ("jump cut")
- The player accelerates (over about 5 frames by default) when pressing or releasing left or right, rather than the velocity being set immediately. The acceleration can be controlled by the learner in the inspector.
- The player can now optionally double-jump.

I think this feels a bit nicer to play (though the jump is still a bit "floaty" for my liking). I would want learning team feedback on whether these tweaks are helpful or whether they complicate the example too much. They were fun to write though.

https://phabricator.endlessm.com/T35700

[Screencast from 2024-10-25 14-47-16.webm](https://github.com/user-attachments/assets/b4225bd4-c1b9-4a3d-afe7-fff81bf20c92)
