### PR TITLE
Document player mods

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+
+[*.gd]
+indent_style = tab
+max_line_length = 100
+
+[*.md]
+indent_style = space
+max_line_length = 80

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -6,6 +6,11 @@ on:
     branches:
       - main
 
+# Cancel any ongoing previous run if a PR is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     name: Linting and Formatting

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -5,6 +5,11 @@ on:
     types:
       - published
 
+# Cancel any ongoing previous run if the job is re-triggered
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pages: write

--- a/.github/workflows/godot-asset-library.yaml
+++ b/.github/workflows/godot-asset-library.yaml
@@ -3,6 +3,11 @@ on:
     types:
       - published
 
+# Cancel any ongoing previous run if the job is re-triggered
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 name: Push to Godot Asset Library
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,9 +9,7 @@ repos:
   - id: check-yaml
   - id: check-added-large-files
 - repo: https://github.com/Scony/godot-gdscript-toolkit
-  # Use this commit from the master branch until the next stable release with
-  # <https://github.com/Scony/godot-gdscript-toolkit/commit/e3c37fa54fb32ad99b0bceb2f17e7bc1ffd99806>
-  rev: f836958a4487e31e3c5ab35c57c7a2128b7e2303
+  rev: 4.3.3
   hooks:
   - id: gdlint
   - id: gdformat

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Moddable Platformer
 
-This mini moddable game project by [Endless OS Foundation](https://endlessos.org) is intended to help ease the learning curve into Godot.
+This mini moddable game project by [Endless OS
+Foundation](https://endlessos.org) is intended to help ease the learning curve
+into Godot.
 
-This sample project allows learners to engage with game creation concepts, applying various modifications to the game itself, all without reading or writing any code.
+This sample project allows learners to engage with game creation concepts,
+applying various modifications to the game itself, all without reading or
+writing any code.
 
 The `doc/MODS.md` file details the mods that have been made available.
 

--- a/doc/MODS.md
+++ b/doc/MODS.md
@@ -23,6 +23,36 @@ Select the `GameLogic` node. From the Inspector, you can adjust the
 Gravity of the world. Decreasing gravity will allow the player to jump
 higher.
 
+### Player
+
+Select the `Player` node. From the Inspector, you can adjust the way the player
+moves in various respects. There are some relatively self-explanatory
+properties:
+
+- **Speed**: How fast the player can move left and right.
+- **Acceleration**: How quickly the player reaches its top left/right speed.
+- **Jump Velocity**: How fast the player moves upwards when jumping. This,
+  together with gravity, controls how high the player can jump.
+- **Double Jump**: If enabled, the player can jump a second time while still in
+  the air. This is quite a common power-up in platform games.
+
+There are also a number of parameters which are commonly used in platform games
+that players may not notice:
+
+- **Jump Cut Factor**: How much to reduce the player's jump when you release
+  the jump key before the top of the jump. Setting this to more than 0% allows
+  the player to control the height of the jump by how long they hold the jump
+  key.
+- **Coyote Time**: How long it takes for the player to start falling after they
+  walk off a ledge. This allows the player to jump if they press the key a
+  moment too late, avoiding frustration. Named after [Wile E.
+  Coyote](https://en.wikipedia.org/wiki/Wile_E._Coyote_and_the_Road_Runner), a
+  cartoon character who often runs off a cliff but does not start falling until
+  he notices he has done so.
+- **Jump Buffer**: How early can the player press jump while still in the air,
+  so that they jump as soon as they land on the floor. This allows the player to
+  jump if they press the key a moment too early, avoiding frustration.
+
 ## Rules
 
 ### Win condition

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -1,5 +1,7 @@
 @tool
+class_name Player
 extends CharacterBody2D
+## A player's character, which can walk, jump, and stomp on enemies.
 
 ## Use this to change the sprite frames of your character.
 @export var sprite_frames: SpriteFrames = _initial_sprite_frames:


### PR DESCRIPTION
This adds a new sections to `MODS.md`, explaining all the parameters of Player, including those I added in #6 which have non-obvious names & semantics. Previously we were relying on the tooltips to explain what they mean but:

1. Sometimes those don't show up, for unknown reasons.
    - #7
3. There's a limit to how much you can explain in a tooltip. For example, you can't link to the Wikipedia page about Wile E. Coyote from a tooltip to explain why Coyote Time is so called.

I also added a few miscellaneous linter & formatting tweaks, which are basically the same as:

- https://github.com/endlessm/godot-block-coding/pull/318