### PR TITLE
Player: Improve interaction between players

### DIFF
--- a/components/player/player.tscn
+++ b/components/player/player.tscn
@@ -38,3 +38,4 @@ animation = &"all"
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(0, -46)
 shape = SubResource("CapsuleShape2D_7x5a4")
+one_way_collision = true


### PR DESCRIPTION
On local multiplayer, other players shouldn't be an obstacle when running. But still is nice to stand on another player for jumping higher. It turns that making the player collision shape "one way" does the trick.