### PR TITLE
Hide instructions on touch devices

### DIFF
--- a/scripts/hud.gd
+++ b/scripts/hud.gd
@@ -25,7 +25,8 @@ func _ready():
 	Global.timer_added.connect(_on_timer_added)
 
 	Input.joy_connection_changed.connect(_on_joy_connection_changed)
-	# TODO: hide entirely if touch controls are visible?
+	if DisplayServer.is_touchscreen_available():
+		%Start.hide()
 
 
 func _on_joy_connection_changed(index: int, connected: bool):


### PR DESCRIPTION
When running on a touchscreen, the (self-explanatory) controls are visible on-screen, and the assumption is that neither a keyboard nor a touchpad is available. So, hide the instructions in that case. If the player does have one or more joypads connected to their touchscreen device, they'll figure it out.

There is no change notification for DisplayServer.is_touchscreen_available(). One might expect that its value could change: for example, only one of the screens currently connected to my computer. In fact, there are only 4 implementations:

- The iOS and Android implementations always return true;
- The web implementation checks whether window.ontouchstart is defined, which AFAICT cannot change;
- The fallback implementation checks whether emulate_touch_from_mouse is set.

So, it is safe to just check it once when the scene loads.