### PR TITLE
Workflows: Download and cache Godot Engine for build

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -46,23 +46,51 @@ jobs:
       - check
     if: ${{ needs.check.outputs.enabled }}
     runs-on: ubuntu-latest
-    container:
-      image: barichello/godot-ci:4.3
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           lfs: true
 
-      - name: Set up export templates
+      - name: Cache Godot Engine downloads
+        id: cache-godot
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/godot
+            build/._sc_
+            build/editor_data/export_templates/${{ env.GODOT_VERSION }}.stable
+          key: godot-${{ env.GODOT_VERSION }}
+
+      - name: Download Godot Engine from GitHub release
+        id: download
+        if: steps.cache-godot.outputs.cache-hit != 'true'
         run: |
-          mkdir -v -p ~/.local/share/godot/export_templates/
-          mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
+          mkdir -p build && cd build
+
+          # Download Godot Engine itself
+          wget https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-stable/Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip && \
+          unzip Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip && \
+          mv Godot_v${GODOT_VERSION}-stable_linux.x86_64 godot
+
+          # Download export templates
+          mkdir -p editor_data/export_templates
+          wget https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-stable/Godot_v${GODOT_VERSION}-stable_export_templates.tpz && \
+          unzip Godot_v${GODOT_VERSION}-stable_export_templates.tpz && \
+          mv templates editor_data/export_templates/${GODOT_VERSION}.stable
+
+          # Tell Godot Engine to run in "self-contained" mode so it looks for
+          # templates here instead of in ~/.local/share/godot/
+          touch ._sc_
 
       - name: Web Build
         run: |
-          mkdir -v -p build/web
-          godot --headless --verbose --export-release "Web" ./build/web/index.html
+          mkdir -v -p build/web && cd build
+
+          # Note that the export path can be confusing; it's relative to the
+          # Godot project path, NOT necessarily the current directory or Godot
+          # binary location
+          ./godot --headless --verbose --path ../ --export-release "Web" ./build/web/index.html
 
       - name: Upload Artifact
         uses: actions/upload-pages-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Godot 4+ specific ignores
 .godot/
+
+# Working directory
+build/


### PR DESCRIPTION
Rather than relying on downloading and executing in a third-party container, we can just grab Godot Engine and the export templates directly from the upstream release page.

We cache these downloads so future runs have the binaries and templates (the latter of which are quite large) available right away for the run.