### PR TITLE
Global: Suppress UNUSED_SIGNAL warning

### DIFF
--- a/scripts/global.gd
+++ b/scripts/global.gd
@@ -5,7 +5,11 @@ signal coin_collected
 signal flag_raised(flag: Flag)
 signal lives_changed
 signal game_ended(ending: Endings)
+
+## Emitted by [GameLogic] when the world's gravitational force is changed.
+@warning_ignore("unused_signal")
 signal gravity_changed(gravity: float)
+
 signal timer_added
 
 enum Endings { WIN, LOSE }


### PR DESCRIPTION
gravity_changed is emitted from GameLogic. Suppress the warning about it not being used in global.gd and add a documentation comment explaining it.

(The name of this signal is a little misleading because, in practice, GameLogic sets the gravitational force exactly once in _ready(). But you could imagine someone adding a way to vary gravity over the course of the game, and the game elements that listen to this signal would behave correctly.)