### PR TITLE
Include web export workflow in git archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,13 @@
 # Normalize EOL for all files that Git considers text files.
 * text=auto eol=lf
 
-# Exclude GitHub Actions-related files from published asset, except the GitHub
-# Pages workflow which learners may find useful to publish their modified game.
-/.github/**                           export-ignore
+# Exclude GitHub Actions-related files from published asset, except the web
+# export & GitHub Pages workflows which learners may find useful to publish
+# their modified game.
+/.github/** export-ignore
 /.github/workflows                   !export-ignore
 /.github/workflows/**                 export-ignore
+/.github/workflows/export.yml        !export-ignore
 /.github/workflows/github-pages.yml  !export-ignore
 /asset-template.json.hb               export-ignore
 


### PR DESCRIPTION
Since commit bb0bef1ae01afa1dac051e4f06a6ea78633c2c0a we have included the GitHub Actions workflow that exports the project for the web & publishes it with GitHub Pages as part of the zip file created by `git archive`, which is what is fetched when the project is downloaded via the Godot Asset Library.

However in commit 80440dee25265c00ea94770d259cfeea4eee91b7 I split that workflow in two, without updating `.gitattributes` accordingly. As a result, the "Publish to GitHub Pages" workflow is present, but the "Build and Export Game" workflow is not; and the former (understandably) fails.

Include it.