### PR TITLE
player: Invert jump velocity parameter & adjust range

### DIFF
--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -34,7 +34,7 @@ const _PLAYER_ACTIONS = {
 
 ## How high does your character jump? Note that the gravity will
 ## be influenced by the [member GameLogic.gravity].
-@export_range(-1000, 1000, 10, "suffix:px/s") var jump_velocity = -880.0
+@export_range(0, 2000, 10, "suffix:px/s") var jump_velocity = 880.0
 
 ## How much should the character's jump be reduced if you let go of the jump
 ## key before the top of the jump? [code]0[/code] means “not at all”;
@@ -107,7 +107,7 @@ func _on_gravity_changed(new_gravity):
 
 
 func _jump():
-	velocity.y = jump_velocity
+	velocity.y = -jump_velocity
 	coyote_timer = 0
 	jump_buffer_timer = 0
 	if double_jump_armed:


### PR DESCRIPTION
When the player jumps, the `y` component of their velocity is set to `jump_velocity`. In Godot, up is negative. So `velocity.y` must be set to a negative number.

But I don't think this means that the `jump_velocity` parameter needs to be negative. And certainly it doesn't make sense for its range to include jumping *downwards* by setting it to a positive number: I have tested this and as expected it doesn't actually work.

Invert `jump_velocity`: set `velocity.y` to its negation when jumping. Adjust the default value accordingly. Change the range to `0`–`2000` rather than `-1000`–`1000`.