### PR TITLE
Miscellaneous cleanups to setters

### DIFF
--- a/components/enemy/enemy.gd
+++ b/components/enemy/enemy.gd
@@ -29,9 +29,8 @@ var direction: int
 
 func _set_speed(new_speed):
 	speed = new_speed
-	if not is_node_ready():
-		await ready
-	_sprite.speed_scale = speed / 100
+	if is_node_ready():
+		_sprite.speed_scale = speed / 100
 
 
 func _ready():

--- a/scripts/coin.gd
+++ b/scripts/coin.gd
@@ -15,9 +15,11 @@ extends Area2D
 
 
 func _set_texture(new_texture: Texture2D):
-	if not is_node_ready():
-		await ready
 	texture = new_texture
+
+	if not is_node_ready():
+		return
+
 	if texture != null:
 		_sprite.texture = texture
 	else:
@@ -32,6 +34,7 @@ func _set_tint(new_tint: Color):
 
 
 func _ready():
+	_set_texture(texture)
 	_set_tint(tint)
 
 

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -80,9 +80,8 @@ func _set_sprite_frames(new_sprite_frames):
 
 func _set_speed(new_speed):
 	speed = new_speed
-	if not is_node_ready():
-		await ready
-	_sprite.speed_scale = speed / 500
+	if is_node_ready():
+		_sprite.speed_scale = speed / 500
 
 
 # Called when the node enters the scene tree for the first time.


### PR DESCRIPTION
This simplifies some logic to adjust sprite speed based on player/enemy speed, and avoids the `await ready` pattern in most setters (which has caused issues for us elsewhere).