### PR TITLE
Simplify handling both players' inputs

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -19,6 +19,7 @@ config/icon="res://icon.svg"
 [autoload]
 
 Global="*res://scripts/global.gd"
+Actions="*res://scripts/actions.gd"
 
 [display]
 

--- a/scripts/actions.gd
+++ b/scripts/actions.gd
@@ -1,0 +1,55 @@
+extends Node
+## Registry of action names for each player
+##
+## This game has actions preconfigured for two players. The [class Player] scene can be configured
+## to respond to inputs for player one or two, or for both players.
+## [br][br]
+## Use [member lookup] to find the full action name for a given player and action.
+
+const _PLAYER_ACTIONS = {
+	Global.Player.ONE:
+	{
+		"jump": &"player_1_jump",
+		"left": &"player_1_left",
+		"right": &"player_1_right",
+	},
+	Global.Player.TWO:
+	{
+		"jump": &"player_2_jump",
+		"left": &"player_2_left",
+		"right": &"player_2_right",
+	},
+	Global.Player.BOTH:
+	{
+		"jump": &"player_both_jump",
+		"left": &"player_both_left",
+		"right": &"player_both_right",
+	},
+}
+
+
+func _ready() -> void:
+	_setup_both_actions()
+
+
+# Sets up the "both" actions, bound to the corresponding events from both players one and two.
+# This is done dynamically so that we don't have to keep them in sync in the project settings.
+func _setup_both_actions() -> void:
+	for action: String in _PLAYER_ACTIONS[Global.Player.BOTH]:
+		var p1: StringName = _PLAYER_ACTIONS[Global.Player.ONE][action]
+		var p2: StringName = _PLAYER_ACTIONS[Global.Player.TWO][action]
+		var both: StringName = _PLAYER_ACTIONS[Global.Player.BOTH][action]
+
+		var deadzone := maxf(InputMap.action_get_deadzone(p1), InputMap.action_get_deadzone(p2))
+		InputMap.add_action(both, deadzone)
+
+		for event: InputEvent in InputMap.action_get_events(p1) + InputMap.action_get_events(p2):
+			InputMap.action_add_event(both, event)
+
+
+## Looks up the full action name for [param player] and [param action].
+## [br][br]
+## For example, [code]Actions.lookup(Global.Player.TWO, "jump")[/code] returns
+## [code]"player_2_jump"[/code].
+func lookup(player: Global.Player, action: StringName) -> StringName:
+	return _PLAYER_ACTIONS[player][action]

--- a/scripts/actions.gd.uid
+++ b/scripts/actions.gd.uid
@@ -1,0 +1,1 @@
+uid://vybbwarmer0p

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -3,21 +3,6 @@ class_name Player
 extends CharacterBody2D
 ## A player's character, which can walk, jump, and stomp on enemies.
 
-const _PLAYER_ACTIONS = {
-	Global.Player.ONE:
-	{
-		"jump": "player_1_jump",
-		"left": "player_1_left",
-		"right": "player_1_right",
-	},
-	Global.Player.TWO:
-	{
-		"jump": "player_2_jump",
-		"left": "player_2_left",
-		"right": "player_2_right",
-	},
-}
-
 ## Which player controls this character?
 @export var player: Global.Player = Global.Player.ONE
 
@@ -118,43 +103,6 @@ func stomp():
 	_jump()
 
 
-func _player_just_pressed(action):
-	if player == Global.Player.BOTH:
-		return (
-			Input.is_action_just_pressed(_PLAYER_ACTIONS[Global.Player.ONE][action])
-			or Input.is_action_just_pressed(_PLAYER_ACTIONS[Global.Player.TWO][action])
-		)
-	return Input.is_action_just_pressed(_PLAYER_ACTIONS[player][action])
-
-
-func _player_just_released(action):
-	if player == Global.Player.BOTH:
-		return (
-			Input.is_action_just_released(_PLAYER_ACTIONS[Global.Player.ONE][action])
-			or Input.is_action_just_released(_PLAYER_ACTIONS[Global.Player.TWO][action])
-		)
-	return Input.is_action_just_released(_PLAYER_ACTIONS[player][action])
-
-
-func _get_player_axis(action_a, action_b):
-	if player == Global.Player.BOTH:
-		return clamp(
-			(
-				Input.get_axis(
-					_PLAYER_ACTIONS[Global.Player.ONE][action_a],
-					_PLAYER_ACTIONS[Global.Player.ONE][action_b]
-				)
-				+ Input.get_axis(
-					_PLAYER_ACTIONS[Global.Player.TWO][action_a],
-					_PLAYER_ACTIONS[Global.Player.TWO][action_b]
-				)
-			),
-			-1,
-			1
-		)
-	return Input.get_axis(_PLAYER_ACTIONS[player][action_a], _PLAYER_ACTIONS[player][action_b])
-
-
 func _physics_process(delta):
 	# Don't move if there are no lives left.
 	if Global.lives <= 0:
@@ -165,7 +113,7 @@ func _physics_process(delta):
 		coyote_timer = (coyote_time + delta)
 		double_jump_armed = false
 
-	if _player_just_pressed("jump"):
+	if Input.is_action_just_pressed(Actions.lookup(player, "jump")):
 		jump_buffer_timer = (jump_buffer + delta)
 
 	if jump_buffer_timer > 0 and (double_jump_armed or coyote_timer > 0):
@@ -173,7 +121,7 @@ func _physics_process(delta):
 
 	# Reduce velocity if the player lets go of the jump key before the apex.
 	# This allows controlling the height of the jump.
-	if _player_just_released("jump") and velocity.y < 0:
+	if Input.is_action_just_released(Actions.lookup(player, "jump")) and velocity.y < 0:
 		velocity.y *= (1 - (jump_cut_factor / 100.00))
 
 	# Add the gravity.
@@ -181,8 +129,7 @@ func _physics_process(delta):
 		velocity.y += gravity * delta
 
 	# Get the input direction and handle the movement/deceleration.
-	# As good practice, you should replace UI actions with custom gameplay actions.
-	var direction = _get_player_axis("left", "right")
+	var direction = Input.get_axis(Actions.lookup(player, "left"), Actions.lookup(player, "right"))
 	if direction:
 		velocity.x = move_toward(
 			velocity.x,


### PR DESCRIPTION
The player-character scene can be configured to respond to player 1's inputs, player 2's inputs, or both. I don't really know why you would want it to respond to both, but it's there.

Previously the both case was implemented by checking the player 1 and player 2 versions of each action, and combining them.

I think it is cleaner to have a "both" version of each action, bound to the union of the player 1 and player 2 input events, and then just check that directly.

Move all this handling to a new Actions global. Set up the "both" actions dynamically (so that we don't have to manually keep them in sync in the project settings).