### PR TITLE
Add deliberately-broken enemy spawner

### DIFF
--- a/components/spawner/enemy_spawner_broken.tscn
+++ b/components/spawner/enemy_spawner_broken.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=3 format=3 uid="uid://bkkta0sx62l3t"]
+
+[ext_resource type="Script" uid="uid://5k8i85vjjqgp" path="res://components/spawner/spawner_broken.gd" id="1_h3ru7"]
+[ext_resource type="PackedScene" uid="uid://dk0xon0k7ga23" path="res://components/enemy/enemy.tscn" id="2_7irji"]
+
+[node name="EnemySpawnerBroken" type="Node2D"]
+script = ExtResource("1_h3ru7")
+scene_to_spawn = ExtResource("2_7irji")

--- a/components/spawner/spawner_broken.gd
+++ b/components/spawner/spawner_broken.gd
@@ -1,0 +1,31 @@
+class_name SpawnerBroken
+extends Node2D
+## @experimental
+## Periodically spawns a scene at this node's position.
+##
+## This could be used, for example, to have a new enemy appear every few seconds.
+## This class is marked experimental because it seems to be buggy.
+
+## Number of seconds to wait between spawning [member scene_to_spawn].
+@export_range(1.0, 600.0, 1.0, "suffix:s", "or_greater") var spawn_interval := 5.0
+
+## Scene to spawn every [member spawn_interval] seconds.
+@export var scene_to_spawn: PackedScene
+
+
+func _ready() -> void:
+	var timer := Timer.new()
+	add_child(timer)
+
+	timer.timeout.connect(spawn)
+
+	# Convert seconds to milliseconds for timer.start() method.
+	# FIXME: Is this correct?? It seems to spawn too fast!
+	timer.start(spawn_interval / 1000)
+
+
+## Spawns an instance of [member scene_to_spawn] at the same position as this node, as a sibling.
+func spawn() -> void:
+	var scene := scene_to_spawn.instantiate()
+	scene.global_position = global_position
+	get_parent().add_child(scene)

--- a/components/spawner/spawner_broken.gd.uid
+++ b/components/spawner/spawner_broken.gd.uid
@@ -1,0 +1,1 @@
+uid://5k8i85vjjqgp


### PR DESCRIPTION
This adds a SpawnerBroken script, and an enemy_spawner_broken scene using that script configured to spawn enemy.tcsn.

The intention is that it spawns the given scene periodically, but something is wrong: it spawns the scene way too frequently, which makes the game unplayably slow.

The bug – signposted with a FIXME comment – is intentional and contrived. It's meant to be a simplified version of a very common class of bug: if you specify a time internal as a `float`, the type alone doesn't tell you whether the units are seconds, milliseconds, etc., and if you get it wrong you will only find out through testing.

The idea is that a learner can fix the issue in at least 4 ways:

1. Increase the spawn_interval property on the instance of the scene in main.tscn.
2. Increase the spawn_interval property in enemy_spawner_broken.tscn.
3. Increase the spawn_interval property in spawner_broken.gd.
4. (The correct fix) Address the FIXME in the code by removing the erroneous conversion to milliseconds.