### PR TITLE
Don't share collision shapes between instances of platforms

### DIFF
--- a/components/platform/platform.tscn
+++ b/components/platform/platform.tscn
@@ -3,9 +3,11 @@
 [ext_resource type="Script" uid="uid://dilh5jyuklov6" path="res://components/platform/platform.gd" id="1_dpc6h"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_i4vtk"]
+resource_local_to_scene = true
 size = Vector2(256, 40)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_o2vn2"]
+resource_local_to_scene = true
 size = Vector2(256, 128)
 
 [sub_resource type="Animation" id="Animation_6232f"]


### PR DESCRIPTION
Previously, the collision shapes were shared between each instance of the scene.

This means that if you placed 2 platforms in a scene, and set one of them to be 2 tiles wide and the other to 3 tiles wide, the collision shapes would both be as wide as the last platform in the scene tree, rather than matching their visible size.

Making the resources local_to_scene causes them to be duplicated when the scene is instanced.
