### PR TITLE
platform: Use different debug colors for collision shapes

### DIFF
--- a/components/platform/platform.tscn
+++ b/components/platform/platform.tscn
@@ -47,6 +47,7 @@ freeze = true
 unique_name_in_owner = true
 position = Vector2(0, -84)
 shape = SubResource("RectangleShape2D_i4vtk")
+debug_color = Color(0.843463, 0.380052, 0, 0.42)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="RigidBody2D"]
 unique_name_in_owner = true


### PR DESCRIPTION
Platforms have two collision shapes: one for the platform itself, and one for the region above the platform which triggers a fall (if that option is enabled).

Give the latter a different debug color.

Also revert commit bf74940: the problem that caused that was actually fixed in commit 6a00fff81c80213bd725e698a94c5c0f3694136c.