### PR TITLE
player: Prevent double-jumping after respawing

### DIFF
--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -312,3 +312,4 @@ func reset():
 	velocity = Vector2.ZERO
 	coyote_timer = 0
 	jump_buffer_timer = 0
+	double_jump_armed = false


### PR DESCRIPTION
Previously, when double_jump was enabled, then if the player lost a life midway through jumping, such as by jumping into the underside of an enemy, then after respawning at the start of the level they could double-jump before landing. This was not intentional. Fix it!