### PR TITLE
dependabot: Group updates for actions/* namespace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    groups:
+      # Group updates for actions owned by GitHub into one PR: they often update
+      # them all at once to bump the Node.JS version.
+      github:
+        patterns:
+          - "actions/*"


### PR DESCRIPTION
It is common for GitHub to release new versions of all their actions in near-lockstep, causing a flood of PRs in each of our projects.

We can't help the fact we have multiple projects, but having read the documentation it looks like we can at least group these updates together.