### PR TITLE
Ignore Patchwork-related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,13 @@ build/
 # binary files like Aseprite projects is likely to be a mistake.
 *.ase
 *.aseprite
+
+# Godot Patchwork addon, bundled editor build, launcher, updater, and
+# config/state files
+/addons/patchwork/
+/godot_editor/
+.patchwork
+.patchwork_version
+patchwork.cfg
+launch-patchwork.exe
+update-patchwork.exe


### PR DESCRIPTION
This is taken from
https://github.com/LilithSilver/patchwork-update-script/pull/6. Including these
upstream makes it easier to prepare bundles with this project plus the patchwork addon & editor build.