### PR TITLE
Always teleport full distance, even with analogue stick input

### DIFF
--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -187,7 +187,7 @@ func _teleport(input_direction: float) -> void:
 	):
 		# TODO: Check if we are teleporting into a wall (in which case the player should lose a
 		# life) or an enemy (in which case maybe the enemy should be telefragged/defeated?)
-		global_position.x += TELEPORT_DISTANCE * input_direction
+		global_position.x += TELEPORT_DISTANCE * signf(input_direction)
 		_teleport_sfx.play()
 
 


### PR DESCRIPTION
_teleport() takes an input_direction in range [-1, 1] as input, and if it is not approximately zero, teleports the player by input_direction * TELEPORT_DISTANCE.

The direction comes from:

	var direction = Input.get_axis(Actions.lookup(player, "left"), Actions.lookup(player, "right"))

When using keyboard or D-pad input, this is always -1, 0, or 1. But with an analogue joystick it can be any value between -1 and 1. (Actually strictly speaking it can be [-1.0, -0.5], 0, or [0.5, 1.0] because the left/right actions' dead zones are set to 0.5.)

Use signf to round any negative value to -1 and any positive value to 1 when calculating how far to teleport the player.