### PR TITLE
ci: Use prek not pre-commit

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -17,13 +17,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
-    - uses: actions/setup-python@v6
-      with:
-        python-version: '3.11'
-    - name: set PY
-      run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-    - uses: actions/cache@v6
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - uses: pre-commit/action@v3.0.1
+    - uses: j178/prek-action@5337cb91e0fa35a7ff31b9ca345126d8bbbcdf16 # v2.0.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-# See https://pre-commit.com for more information
-# See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0

--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ community platform and submit pull requests via
 
 ### Development environment
 
-Please use [pre-commit](https://pre-commit.com) to check for correct formatting
-and other issues before creating commits. To do this automatically, you can add
-it as a git hook:
+Please use [prek](https://prek.j178.dev/) to check for correct formatting
+and other issues before creating commits.
 
+First, follow the [prek installation
+instructions](https://prek.j178.dev/installation/) for your OS, if you don't
+already have it installed. Now add it as a git hook by running this in your
+clone of this repo:
+
+```bash
+prek install
 ```
-# If you don't have pre-commit already:
-pip install pre-commit
 
-# Setup git hook:
-pre-commit install
-```
-
-Now `pre-commit` will run automatically on `git commit`!
+Now `prek` will run automatically on `git commit`!


### PR DESCRIPTION
Update the README accordingly. Continue to use .pre-commit-config.yaml for compatibility with existing clones.